### PR TITLE
Add a way to choose which repository should be searched 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
 language: ruby
 rvm:
-  - 1.9.3
   - 2.2.0

--- a/README.md
+++ b/README.md
@@ -17,6 +17,21 @@ alfi picasso
 <img src="https://raw.github.com/cesarferreira/alfi/master/extras/images/terminal01.gif" />
 </p>
 
+
+Search for `something` by repository
+
+```bash
+alfi picasso -r m
+```
+
+This will search picasso only on maven, you can also define multiple repositories like:
+
+```bash
+alfi picasso -r mc -r jc
+```
+
+This will search picasso on mavenCentral and jCenter
+
 **Final step:** Copy the library you want to your `build.gradle` and sync it
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ alfi picasso
 Search for `something` by repository
 
 ```bash
-alfi picasso -r m
+alfi picasso --repository maven
 ```
 
 This will search picasso only on maven, you can also define multiple repositories like:
 
 ```bash
-alfi picasso -r mc -r jc
+alfi picasso -r mavenCentral -r jCenter
 ```
 
 This will search picasso on mavenCentral and jCenter

--- a/lib/alfi/cli.rb
+++ b/lib/alfi/cli.rb
@@ -10,7 +10,7 @@ class Alfi::Cli
   end
 
   def call(arguments)
-    @searchType = []
+    @search_type = []
     create_options_parser
     search_param = @all_defined_arguments.include?(arguments.first) ? nil : arguments.shift
     @bintray_username = nil
@@ -21,7 +21,7 @@ class Alfi::Cli
 
     exit_with("Missing query parameter\n".red + @opt_parser.help) unless search_param
 
-    Alfi::Search.new.call(search_param, @searchType)
+    Alfi::Search.new.call(search_param, @search_type)
   end
 
   def create_options_parser
@@ -56,22 +56,22 @@ class Alfi::Cli
         puts Alfi::VERSION
         exit
       end
-      opts.on('-r REPOSITORY_NAME', '--repository REPOSITORY_NAME', 'If should search on m (maven), jc (jCenter) or mc (mavenCentral) ') do |repository_name|
-        if repository_name != "m" && repository_name != "jc" && repository_name != "mc"
-          puts "Please choose one of the following m, jc or mc"
+      opts.on('-r REPOSITORY_NAME', '--repository REPOSITORY_NAME', 'If should search on maven, jCenter or mavenCentral ') do |repository_name|
+        if repository_name != "maven" && repository_name != "jcenter" && repository_name != "mavencentral"
+          puts "Please choose one of the following maven, jcenter or mavencentral"
           exit
         end
 
-        if repository_name == "m"
-          @searchType << "m"
+        if repository_name.downcase == "maven"
+          @search_type << "m"
         end
 
-        if repository_name == "mc"
-          @searchType << "maven"
+        if repository_name.downcase == "mavencentral"
+          @search_type << "maven"
         end
 
-        if repository_name == "jc"
-          @searchType << "jcenter"
+        if repository_name.downcase == "jcenter"
+          @search_type << "jcenter"
         end
       end
 

--- a/lib/alfi/cli.rb
+++ b/lib/alfi/cli.rb
@@ -10,7 +10,7 @@ class Alfi::Cli
   end
 
   def call(arguments)
-    @searchType = Array.new
+    @searchType = []
     create_options_parser
     search_param = @all_defined_arguments.include?(arguments.first) ? nil : arguments.shift
     @bintray_username = nil

--- a/lib/alfi/cli.rb
+++ b/lib/alfi/cli.rb
@@ -10,6 +10,7 @@ class Alfi::Cli
   end
 
   def call(arguments)
+    @searchType = Array.new
     create_options_parser
     search_param = @all_defined_arguments.include?(arguments.first) ? nil : arguments.shift
     @bintray_username = nil
@@ -20,7 +21,7 @@ class Alfi::Cli
 
     exit_with("Missing query parameter\n".red + @opt_parser.help) unless search_param
 
-    Alfi::Search.new.call(search_param)
+    Alfi::Search.new.call(search_param, @searchType)
   end
 
   def create_options_parser
@@ -29,6 +30,8 @@ class Alfi::Cli
       '--user',
       '-k',
       '--key',
+      '-r',
+      '--repository',
       '-h',
       '--help',
       '-v',
@@ -52,6 +55,24 @@ class Alfi::Cli
       opts.on('-v', '--version', 'Displays version') do
         puts Alfi::VERSION
         exit
+      end
+      opts.on('-r REPOSITORY_NAME', '--repository REPOSITORY_NAME', 'If should search on m (maven), jc (jCenter) or mc (mavenCentral) ') do |repository_name|
+        if repository_name != "m" && repository_name != "jc" && repository_name != "mc"
+          puts "Please choose one of the following m, jc or mc"
+          exit
+        end
+
+        if repository_name == "m"
+          @searchType << "m"
+        end
+
+        if repository_name == "mc"
+          @searchType << "maven"
+        end
+
+        if repository_name == "jc"
+          @searchType << "jcenter"
+        end
       end
 
       opts.separator  "\nNow you are using alfi credentials for Bintray".yellow

--- a/lib/alfi/providers/base.rb
+++ b/lib/alfi/providers/base.rb
@@ -1,10 +1,10 @@
 class Alfi::Providers::Base
-  def initialize(query, searchType)
+  def initialize(query, search_type)
     @query = query
     @uri = URI.parse(query_url(query))
     @http = Net::HTTP.new(@uri.host, @uri.port)
     @request = Net::HTTP::Get.new(@uri.request_uri)
-    @searchType = searchType
+    @search_type = search_type
     request_extensions if self.class.method_defined?(:request_extensions)
   end
 

--- a/lib/alfi/providers/base.rb
+++ b/lib/alfi/providers/base.rb
@@ -1,9 +1,10 @@
 class Alfi::Providers::Base
-  def initialize(query)
+  def initialize(query, searchType)
     @query = query
     @uri = URI.parse(query_url(query))
     @http = Net::HTTP.new(@uri.host, @uri.port)
     @request = Net::HTTP::Get.new(@uri.request_uri)
+    @searchType = searchType
     request_extensions if self.class.method_defined?(:request_extensions)
   end
 

--- a/lib/alfi/providers/bintray.rb
+++ b/lib/alfi/providers/bintray.rb
@@ -36,7 +36,7 @@ class Alfi::Providers::Bintray < Alfi::Providers::Base
   end
 
   def call
-    if @searchType.empty? || @searchType.include?('jcenter') || @searchType.include?('maven')
+    if @search_type.empty? || @search_type.include?('jcenter') || @search_type.include?('maven')
       begin
         response = @http.request(@request)
       rescue SocketError
@@ -50,7 +50,7 @@ class Alfi::Providers::Bintray < Alfi::Providers::Base
       add_to_list "  # #{'-'*20}Bintray#{'-'*20}" if response_json.size > 0
 
       response_json.group_by { |package| package['repo'] }.each do |provider, repositories|
-        if @searchType.empty? || @searchType.include?(provider)
+        if @search_type.empty? || @search_type.include?(provider)
           add_to_list "  # #{PROVIDERS_TEXTS[provider]}"
           repositories.each do |repo|
             add_repo_to_list "#{repo['system_ids'][0]}:#{repo['latest_version']}" if repo['system_ids'].size > 0

--- a/lib/alfi/providers/bintray.rb
+++ b/lib/alfi/providers/bintray.rb
@@ -36,22 +36,26 @@ class Alfi::Providers::Bintray < Alfi::Providers::Base
   end
 
   def call
-    begin
-      response = @http.request(@request)
-    rescue SocketError
-      puts "Internet Connection not available".red
-      exit 1
-    end
+    if @searchType.empty? || @searchType.include?('jcenter') || @searchType.include?('maven')
+      begin
+        response = @http.request(@request)
+      rescue SocketError
+        puts "Internet Connection not available".red
+        exit 1
+      end
 
-    return if response.code != '200'
-    response_json = JSON.parse(response.body || '{}')
+      return if response.code != '200'
+      response_json = JSON.parse(response.body || '{}')
 
-    add_to_list "  # #{'-'*20}Bintray#{'-'*20}" if response_json.size > 0
+      add_to_list "  # #{'-'*20}Bintray#{'-'*20}" if response_json.size > 0
 
-    response_json.group_by { |package| package['repo'] }.each do |provider, repositories|
-      add_to_list "  # #{PROVIDERS_TEXTS[provider]}"
-      repositories.each do |repo|
-        add_repo_to_list "#{repo['system_ids'][0]}:#{repo['latest_version']}" if repo['system_ids'].size > 0
+      response_json.group_by { |package| package['repo'] }.each do |provider, repositories|
+        if @searchType.empty? || @searchType.include?(provider)
+          add_to_list "  # #{PROVIDERS_TEXTS[provider]}"
+          repositories.each do |repo|
+            add_repo_to_list "#{repo['system_ids'][0]}:#{repo['latest_version']}" if repo['system_ids'].size > 0
+          end
+        end
       end
     end
   end

--- a/lib/alfi/providers/maven.rb
+++ b/lib/alfi/providers/maven.rb
@@ -4,7 +4,7 @@ class Alfi::Providers::Maven < Alfi::Providers::Base
   end
 
   def call
-    if @searchType.empty? || @searchType.include?('m')
+    if @search_type.empty? || @search_type.include?('m')
       begin
         response = @http.request(@request)
       rescue SocketError

--- a/lib/alfi/providers/maven.rb
+++ b/lib/alfi/providers/maven.rb
@@ -4,29 +4,31 @@ class Alfi::Providers::Maven < Alfi::Providers::Base
   end
 
   def call
-    begin
-      response = @http.request(@request)
-    rescue SocketError
-      puts "Internet Connection not available".red
-      exit 1
-    end
-
-    if response.code == '200'
-      result = JSON.parse(response.body)
-
-      num_results = result['response']['numFound']
-
-      if num_results == 0
-        suggestions = (result['spellcheck']['suggestions'].last || {})['suggestion']
-        add_suggestions(suggestions) if suggestions
-      else
-        add_to_list "  # #{'-'*20}Maven.org#{'-'*20}"
-        add_to_list '  # mavenCentral()'
+    if @searchType.empty? || @searchType.include?('m')
+      begin
+        response = @http.request(@request)
+      rescue SocketError
+        puts "Internet Connection not available".red
+        exit 1
       end
-      result['response']['docs'].each { |doc| add_repo_to_list "#{doc['id']}:#{doc['latestVersion']}" }
-    else
-      puts "Error: #{response.code}\n#{response}".red
-      exit 1
+
+      if response.code == '200'
+        result = JSON.parse(response.body)
+
+        num_results = result['response']['numFound']
+
+        if num_results == 0
+          suggestions = (result['spellcheck']['suggestions'].last || {})['suggestion']
+          add_suggestions(suggestions) if suggestions
+        else
+          add_to_list "  # #{'-'*20}Maven.org#{'-'*20}"
+          add_to_list '  # mavenCentral()'
+        end
+        result['response']['docs'].each { |doc| add_repo_to_list "#{doc['id']}:#{doc['latestVersion']}" }
+      else
+        puts "Error: #{response.code}\n#{response}".red
+        exit 1
+      end
     end
   end
 end

--- a/lib/alfi/providers/offline.rb
+++ b/lib/alfi/providers/offline.rb
@@ -1,6 +1,6 @@
 # require 'alfi/providers/base'
 class Alfi::Providers::Offline < Alfi::Providers::Base
-  def initialize(query)
+  def initialize(query, searchType)
     @query = query
   end
 

--- a/lib/alfi/providers/offline.rb
+++ b/lib/alfi/providers/offline.rb
@@ -1,6 +1,6 @@
 # require 'alfi/providers/base'
 class Alfi::Providers::Offline < Alfi::Providers::Base
-  def initialize(query, searchType)
+  def initialize(query, search_type)
     @query = query
   end
 

--- a/lib/alfi/search.rb
+++ b/lib/alfi/search.rb
@@ -9,14 +9,14 @@ class Alfi::Search
     exit 1
   end
 
-  def call(search_param, searchType)
+  def call(search_param, search_type)
     return puts 'The search needs 3+ characters'.red if search_param.size < 3
     puts "Searching...\n"
 
-    Alfi::Providers.all.each { |cc| cc.new(search_param, searchType).call }
+    Alfi::Providers.all.each { |cc| cc.new(search_param, search_type).call }
 
     exit_with('No results'.red) if $result_list.empty? && $suggestions.empty?
-    num_results = total_results()
+    num_results = total_results_count()
 
     if num_results > 0
       puts "\ndependencies {\n"
@@ -30,7 +30,7 @@ class Alfi::Search
     puts "Did you mean: #{$suggestions.join(', ').yellow}"
   end
 
-  def total_results()
+  def total_results_count()
     return $result_list.count { |r| r.strip[0] != '#' }
   end
 end

--- a/lib/alfi/search.rb
+++ b/lib/alfi/search.rb
@@ -9,11 +9,11 @@ class Alfi::Search
     exit 1
   end
 
-  def call(search_param)
+  def call(search_param, searchType)
     return puts 'The search needs 3+ characters'.red if search_param.size < 3
     puts "Searching...\n"
 
-    Alfi::Providers.all.each { |cc| cc.new(search_param).call }
+    Alfi::Providers.all.each { |cc| cc.new(search_param, searchType).call }
 
     exit_with('No results'.red) if $result_list.empty? && $suggestions.empty?
     num_results = $result_list.count { |r| r.strip[0] != '#' }

--- a/lib/alfi/search.rb
+++ b/lib/alfi/search.rb
@@ -16,7 +16,7 @@ class Alfi::Search
     Alfi::Providers.all.each { |cc| cc.new(search_param, search_type).call }
 
     exit_with('No results'.red) if $result_list.empty? && $suggestions.empty?
-    num_results = total_results_count()
+    num_results = total_results_count
 
     if num_results > 0
       puts "\ndependencies {\n"
@@ -30,7 +30,7 @@ class Alfi::Search
     puts "Did you mean: #{$suggestions.join(', ').yellow}"
   end
 
-  def total_results_count()
+  def total_results_count
     return $result_list.count { |r| r.strip[0] != '#' }
   end
 end

--- a/lib/alfi/search.rb
+++ b/lib/alfi/search.rb
@@ -16,7 +16,7 @@ class Alfi::Search
     Alfi::Providers.all.each { |cc| cc.new(search_param, searchType).call }
 
     exit_with('No results'.red) if $result_list.empty? && $suggestions.empty?
-    num_results = $result_list.count { |r| r.strip[0] != '#' }
+    num_results = total_results()
 
     if num_results > 0
       puts "\ndependencies {\n"
@@ -28,5 +28,9 @@ class Alfi::Search
 
     return if $suggestions.empty?
     puts "Did you mean: #{$suggestions.join(', ').yellow}"
+  end
+
+  def total_results()
+    return $result_list.count { |r| r.strip[0] != '#' }
   end
 end

--- a/spec/alfi_spec.rb
+++ b/spec/alfi_spec.rb
@@ -2,20 +2,20 @@ require 'spec_helper'
 
 describe Alfi do
   it 'Test the query_url' do
-    str = Alfi::Providers::Maven.new('picasso', Array.new).query_url('picasso')
+    str = Alfi::Providers::Maven.new('picasso', []).query_url('picasso')
     expect(str).to eq 'http://search.maven.org/solrsearch/select?q=picasso&rows=350&wt=json'
   end
 
   it 'Test search with repository' do
     maven = Alfi::Search.new
-    maven.call('sPref', Array.new(1, "maven"))
-    expect(maven.total_results).to be >= 1
+    maven.call('sPref', ["maven"])
+    expect(maven.total_results_count).to be >= 1
   end
 
   context 'suggestions' do
     it 'should return 0 suggestions' do
       VCR.use_cassette('search_active_android_with_no_suggestions') do
-        maven_provider = Alfi::Providers::Maven.new('active-android', Array.new)
+        maven_provider = Alfi::Providers::Maven.new('active-android', [])
 
         expect(maven_provider).to_not receive(:add_suggestions)
         maven_provider.call
@@ -24,7 +24,7 @@ describe Alfi do
 
     it 'should return suggestions' do
       VCR.use_cassette('search_picassoa_with_suggestions') do
-        maven_provider = Alfi::Providers::Maven.new('picassoa', Array.new)
+        maven_provider = Alfi::Providers::Maven.new('picassoa', [])
 
         expect(maven_provider).to receive(:add_suggestions).with(array_including('picasso', 'piccolo'))
         maven_provider.call

--- a/spec/alfi_spec.rb
+++ b/spec/alfi_spec.rb
@@ -6,6 +6,12 @@ describe Alfi do
     expect(str).to eq 'http://search.maven.org/solrsearch/select?q=picasso&rows=350&wt=json'
   end
 
+  it 'Test search with repository' do
+    maven = Alfi::Search.new
+    maven.call('sPref', Array.new(1, "maven"))
+    expect(maven.total_results).to be >= 1
+  end
+
   context 'suggestions' do
     it 'should return 0 suggestions' do
       VCR.use_cassette('search_active_android_with_no_suggestions') do

--- a/spec/alfi_spec.rb
+++ b/spec/alfi_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Alfi do
   it 'Test the query_url' do
-    str = Alfi::Providers::Maven.new('picasso').query_url('picasso')
+    str = Alfi::Providers::Maven.new('picasso', Array.new).query_url('picasso')
     expect(str).to eq 'http://search.maven.org/solrsearch/select?q=picasso&rows=350&wt=json'
   end
 
   context 'suggestions' do
     it 'should return 0 suggestions' do
       VCR.use_cassette('search_active_android_with_no_suggestions') do
-        maven_provider = Alfi::Providers::Maven.new('active-android')
+        maven_provider = Alfi::Providers::Maven.new('active-android', Array.new)
 
         expect(maven_provider).to_not receive(:add_suggestions)
         maven_provider.call
@@ -18,7 +18,7 @@ describe Alfi do
 
     it 'should return suggestions' do
       VCR.use_cassette('search_picassoa_with_suggestions') do
-        maven_provider = Alfi::Providers::Maven.new('picassoa')
+        maven_provider = Alfi::Providers::Maven.new('picassoa', Array.new)
 
         expect(maven_provider).to receive(:add_suggestions).with(array_including('picasso', 'piccolo'))
         maven_provider.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,7 @@ VCR.configure do |c|
   c.cassette_library_dir = 'spec/cassettes'
   c.hook_into :webmock
   c.configure_rspec_metadata!
+  c.allow_http_connections_when_no_cassette = true
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
So now it is possible to search only maven, jcenter or mavencentral repositories, using "-r" or "--repository". Additionally the user can search more than 1 repository by doing 
       `alfi "repository_name" -r m -r jc`
This will search in maven and jcenter repositores
