### PR TITLE
#21 Make output compatible with Kotlin scripts

### DIFF
--- a/lib/alfi/providers/base.rb
+++ b/lib/alfi/providers/base.rb
@@ -25,6 +25,6 @@ class Alfi::Providers::Base
   end
 
   def add_repo_to_list(package)
-    $result_list << "  implementation '#{package}'".green
+    $result_list << "  implementation(\"#{package}\")".green
   end
 end


### PR DESCRIPTION
Kotlin requires parenthesis and double quotes
Groovy usually omits them but is totally fine with parenthesis and double quotes.

See https://github.com/cesarferreira/alfi/issues/21